### PR TITLE
Small patch to support regression + fix minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ separate columns.
 ./dataset/amazon/load_data.py to correctly read and iterate through your CSV
 data. This might involve adjusting column names, data types, and loading logic.
 
+#### If adapting to regression
+Set the `supervised_loss: mse_loss` property in the config. Value can be any of the [pytorch functional losses](https://pytorch.org/docs/stable/nn.functional.html#loss-functions).
+
+Set `num_classes: 1` property in the config.
+
+Finally, currently only RMSE is supported as a validation metric, set `perf_metric: RMSE` in the config.
+
 ### How to skip pretraining and use LANISTR for supervised learning only
 
 **Choose a finetuning config file:** Select one of the provided finetuning

--- a/lanistr/third_party/tabnet/tabular_encoder.py
+++ b/lanistr/third_party/tabnet/tabular_encoder.py
@@ -433,13 +433,13 @@ class TabNetPretraining(torch.nn.Module):
       prior = 1 - masked_obf_vars
       masked_steps_out, _ = self.encoder(masked_x, prior=prior)
       res = self.decoder(masked_steps_out)
-      masked_last_hidden_state = torch.sum(masked_steps_out, dim=0)
+      masked_last_hidden_state = torch.sum(torch.stack(masked_steps_out, dim=0), dim=0)
       masked_loss = self.compute_loss(res, embedded_x, masked_obf_vars)
 
       unmasked_steps_out, _ = self.encoder(embedded_x)
       unmasked_res = self.decoder(unmasked_steps_out)
       unmasked_obf_vars = torch.ones(embedded_x.shape).to(x.device)
-      unmasked_last_hidden_state = torch.sum(unmasked_steps_out, dim=0)
+      unmasked_last_hidden_state = torch.sum(torch.stack(unmasked_steps_out, dim=0), dim=0)
       unmasked_loss = self.compute_loss(
           unmasked_res, embedded_x, unmasked_obf_vars
       )

--- a/lanistr/trainer.py
+++ b/lanistr/trainer.py
@@ -182,7 +182,7 @@ class Trainer:
         "Pretraining ends for lanistr. Best epoch was at epoch=%d", best_epoch
     )
     print_only_by_main_process(
-        "Pretraining ends for lanistr. Best epoch was at epoch=%d", best_epoch
+        "Pretraining ends for lanistr. Best epoch was at epoch=%d".format(best_epoch)
     )
 
   def pretrain_epoch(

--- a/lanistr/trainer.py
+++ b/lanistr/trainer.py
@@ -109,7 +109,7 @@ class Trainer:
       )
       if os.path.exists(latest_checkpoint_path):
         print_only_by_main_process(
-            "Initializing the entire model from previous pretrain"
+            "Initializing the optimizer from previous pretrain"
         )
         loc = "cuda:{}".format(self.args.device)
         latest_checkpoint = torch.load(latest_checkpoint_path, map_location=loc)

--- a/lanistr/utils/common_utils.py
+++ b/lanistr/utils/common_utils.py
@@ -108,6 +108,13 @@ def get_metrics(args):
             num_classes=args.num_classes, task="binary"
         ).to(args.device)
 
+    elif args.num_classes == 1: # Assume 1 class only for regression
+      metric_names.append("RMSE")
+      for phase in ["train", "test"]:
+        metrics[phase]["RMSE"] = torchmetrics.MeanSquaredError(
+            squared=False
+        ).to(args.device)
+
   return metrics, metric_names
 
 


### PR DESCRIPTION
Essentially just allow easy config modification of loss function to handle regression through configuring `num_classes`, `supervised_loss` and `perf_metric`. 

Piped in RMSE as the default validation metric for all `num_classes: 1` scenarios.

Still up to user to configure the correct `load_data`. Document usage in README.

Also fixed some bugs encountered when running the model:
1. Pretraining TabNet implementation does not correctly handle its step outputs.
2. Would get recurring device placement issues when trying to run in pretraining mode with DataParallel on multiple GPUs - as loss would be put onto `args.device` not the device that the batched data would be piped to using DataParallel.
3. Put in missing `.format` at the end of pretrain.

Minor QoL: Fixed typo in optimizer load logging.